### PR TITLE
54 entropy uses map to store frequncies a vector should be used

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -56,7 +56,7 @@ float Common::Entropy(string trait){
     float result = 0;
     vector<unsigned long> frequencies(256);
     for (char c : bytes){
-      frequencies[static_cast<unsigned char>(c)]++;
+	frequencies[static_cast<unsigned char>(c)]++;
     }
     for (auto count : frequencies){
 	if(count > 0){

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -54,13 +54,15 @@ vector<char> Common::TraitToChar(string trait){
 float Common::Entropy(string trait){
     vector<char> bytes = TraitToChar(trait);
     float result = 0;
-    map<char,int> frequencies;
+    vector<unsigned long> frequencies(256);
     for (char c : bytes){
-        frequencies[c]++;
+      frequencies[static_cast<unsigned char>(c)]++;
     }
-    for (pair<char,int> p : frequencies) {
-        float freq = static_cast<float>( p.second ) / bytes.size();
-        result -= freq * log2(freq) ;
+    for (auto count : frequencies){
+	if(count > 0){
+	    float freq = static_cast<float>( count ) / bytes.size();
+	    result -= freq * log2(freq);
+	}
     }
     return result;
 }


### PR DESCRIPTION
This is a speed improvement in the calculation of the entropy.