### PR TITLE
Masking CIL_INS_NOP operations and fixing generic interface regression.

### DIFF
--- a/src/binlex.cpp
+++ b/src/binlex.cpp
@@ -122,7 +122,7 @@ int main(int argc, char **argv){
             if (cil_decompiler.Decompile(section.data, section.size, si) == false){
                     continue;
             }
-	        si++;
+            si++;
         }
 	cil_decompiler.WriteTraits();
         return EXIT_SUCCESS;

--- a/src/binlex.cpp
+++ b/src/binlex.cpp
@@ -119,10 +119,10 @@ int main(int argc, char **argv){
             if (cil_decompiler.Setup(CIL_DECOMPILER_TYPE_ALL) == false){
                 return 1;
             }
-	    if (cil_decompiler.Decompile(section.data, section.size, si) == false){
-                continue;
-	    }
-	    si++;
+            if (cil_decompiler.Decompile(section.data, section.size, si) == false){
+                    continue;
+            }
+	        si++;
         }
 	cil_decompiler.WriteTraits();
         return EXIT_SUCCESS;

--- a/src/cil.cpp
+++ b/src/cil.cpp
@@ -585,15 +585,15 @@ vector<json> CILDecompiler::GetTraits(){
         if ((sections[i].function_traits.size() > 0) && (type == CIL_DECOMPILER_TYPE_ALL 
         || type == CIL_DECOMPILER_TYPE_FUNCS)){
             for(auto trait : sections[i].function_traits) {
-		json jdata(GetTrait(trait));
-		traitsjson.push_back(jdata);
+		        json jdata(GetTrait(trait));
+		        traitsjson.push_back(jdata);
             }
         }
         if ((sections[i].block_traits.size() > 0) && (type == CIL_DECOMPILER_TYPE_ALL 
         || type == CIL_DECOMPILER_TYPE_BLCKS)){
             for(auto trait : sections[i].block_traits) {
                 json jdata(GetTrait(trait));
-		traitsjson.push_back(jdata);
+		        traitsjson.push_back(jdata);
             }
         }
     }

--- a/src/cil.cpp
+++ b/src/cil.cpp
@@ -446,7 +446,7 @@ bool CILDecompiler::Decompile(void *data, int data_size, int index){
             ctrait->edges = num_edges;
             ctrait->size = SizeOfTrait(*instructions);
             ctrait->invalid_instructions = 0; //TODO
-            ctrait->type = "block"; //TODO support both types
+            ctrait->type = "block";
             ctrait->corpus = string(sections[index].corpus);
             //The cyclomatic complexity differs by type of trait.
             //Which for now only supports block.
@@ -510,11 +510,16 @@ string CILDecompiler::ConvTraitBytes(vector< Instruction* > allinst) {
     string rstr = "";
     string fstr = "";
     for(auto inst : allinst) {
-        char hexbytes[3];
-        sprintf(hexbytes, "%02x", inst->instruction);
-        hexbytes[2] = '\0';
-        rstr.append(string(hexbytes));
-        rstr.append(" ");
+        if(inst->instruction == CIL_INS_NOP) {
+            rstr.append("??");
+            rstr.append(" ");
+        } else {
+            char hexbytes[3];
+            sprintf(hexbytes, "%02x", inst->instruction);
+            hexbytes[2] = '\0';
+            rstr.append(string(hexbytes));
+            rstr.append(" ");
+        }
         for(int i = 0; i < inst->operand_size/8; i++) {
             rstr.append("??");
             rstr.append(" ");

--- a/src/cil.cpp
+++ b/src/cil.cpp
@@ -585,15 +585,15 @@ vector<json> CILDecompiler::GetTraits(){
         if ((sections[i].function_traits.size() > 0) && (type == CIL_DECOMPILER_TYPE_ALL 
         || type == CIL_DECOMPILER_TYPE_FUNCS)){
             for(auto trait : sections[i].function_traits) {
-		        json jdata(GetTrait(trait));
-		        traitsjson.push_back(jdata);
+                json jdata(GetTrait(trait));
+                traitsjson.push_back(jdata);
             }
         }
         if ((sections[i].block_traits.size() > 0) && (type == CIL_DECOMPILER_TYPE_ALL 
         || type == CIL_DECOMPILER_TYPE_BLCKS)){
             for(auto trait : sections[i].block_traits) {
                 json jdata(GetTrait(trait));
-		        traitsjson.push_back(jdata);
+                traitsjson.push_back(jdata);
             }
         }
     }


### PR DESCRIPTION
Example of masked `CIL_INS_NOP` operations:
```
{
    "average_instructions_per_block": 8,
    "blocks": 1,
    "bytes": "00 00 03 6f 36 00 00 0a 0a 16 0b 2b 25",
    "bytes_entropy": 2.931208848953247,
    "bytes_sha256": "764857c6428491ad194da1f5cf988b8c75740ab68056aa2fd887dda9bafca262",
    "corpus": "default",
    "cyclomatic_complexity": 2,
    "edges": 1,
    "file_sha256": "b81a678d5dc18cd801b443f22e7e309a6657ace3a8bf88cfe0b93ca3f4656585",
    "file_tlsh": "7D2523A82BE48B05CA690FBC9475C7A407BAADCFB861D37ECE0556C93C077825F11978",
    "instructions": 8,
    "invalid_instructions": 0,
    "mode": "pe:cil",
    "offset": 0,
    "size": 13,
    "trait": "?? ?? 03 6f ?? ?? ?? ?? 0a 16 0b 2b ??",
    "trait_entropy": 2.5849626064300537,
    "trait_sha256": "5b252d4279bb1310f31488412a3d8dbfb29ca61adbe3c33e9124c7458dc6d4d7",
    "type": "block"
}
```