### PR TITLE
Changes:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,6 +207,9 @@ target_include_directories(binlex
         ${TLSH_INCLUDE_DIRS}
 )
 
+if ( CMAKE_COMPILER_IS_GNUCC )
+    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+endif()
 add_executable(binlex-bin
     src/binlex.cpp
 )

--- a/include/common.h
+++ b/include/common.h
@@ -19,6 +19,7 @@
 #include <capstone/capstone.h>
 #include <tlsh.h>
 #include <stdexcept>
+#include <chrono>
 #include "args.h"
 
 extern "C" {
@@ -66,6 +67,9 @@ extern binlex::Args g_args;
 #define PRINT_ERROR_AND_EXIT(...) { fprintf(stderr, __VA_ARGS__); exit(EXIT_FAILURE); }
 void print_data(string title, void *data, uint32_t size);
 #define PRINT_DATA(title, data, size) { print_data(title, data, size); }
+
+#define PERF_START(tag) { binlex::TimedCode *tc = new binlex::TimedCode(tag);
+#define PERF_END tc->Print(); }
 
 namespace binlex {
     class Common{
@@ -183,6 +187,20 @@ namespace binlex {
          * @param size The size of the data to collect
          */
         BINLEX_EXPORT static void Hexdump(const char * desc, const void * addr, const int len);
+    };
+
+
+    class TimedCode {
+        /**
+        This class contains functionality for binlex code instrumentation.
+        */
+        private:
+            std::chrono::steady_clock::time_point start;
+            const char *print_tag;
+        public:
+            TimedCode(const char *tag);
+            void Print();
+            ~TimedCode() {};
     };
 }
 

--- a/include/decompiler.h
+++ b/include/decompiler.h
@@ -232,7 +232,7 @@ namespace binlex {
         @param address the address to check
         @return bool
         */
-        BINLEX_EXPORT bool IsAddress(map<uint64_t, uint> &addresses, uint64_t address, uint index);
+        BINLEX_EXPORT bool IsAddress(map<uint64_t, uint> &addresses, uint64_t address);
         /**
         Checks if Instruction is Wildcard Instruction
         @param insn the instruction

--- a/include/decompilerbase.h
+++ b/include/decompilerbase.h
@@ -43,20 +43,16 @@ namespace binlex {
             /**
              * Set Threads and Thread Cycles, via pybind11
              * @param threads number of threads
-             * @param thread_cycles thread cycles
-             * @param index the section index
              */
-            BINLEX_EXPORT void py_SetThreads(uint threads, uint thread_cycles, uint thread_sleep);
+            BINLEX_EXPORT void py_SetThreads(uint threads);
             /**
              * Sets The Corpus Name, via pybind11
              * @param corpus pointer to corpus name
-             * @param index the section index
              */
             BINLEX_EXPORT void py_SetCorpus(const char *corpus);
             /**
              *Specify if instruction traits are collected, via pybind11
              *@param instructions bool to collect instructions traits or not
-             *@param index the section index
              */
             BINLEX_EXPORT void py_SetInstructions(bool instructions);
             /**

--- a/src/auto.cpp
+++ b/src/auto.cpp
@@ -90,7 +90,7 @@ int AutoLex::ProcessFile(char *file_path){
             }
 
             decompiler.Setup(characteristics.arch, characteristics.mode);
-            for (int i = 0; i < pe.total_exec_sections; i++) {
+            for (uint32_t i = 0; i < pe.total_exec_sections; i++) {
                 if (pe.sections[i].data != NULL) {
                     decompiler.AppendQueue(pe.sections[i].functions, DECOMPILER_OPERAND_TYPE_FUNCTION, i);
                     decompiler.Decompile(pe.sections[i].data, pe.sections[i].size, pe.sections[i].offset, i);
@@ -120,7 +120,7 @@ int AutoLex::ProcessFile(char *file_path){
         }
 
         decompiler.Setup(characteristics.arch, characteristics.mode);
-        for (int i = 0; i < elf.total_exec_sections; i++){
+        for (uint32_t i = 0; i < elf.total_exec_sections; i++){
             if (elf.sections[i].data != NULL){
                 decompiler.AppendQueue(elf.sections[i].functions, DECOMPILER_OPERAND_TYPE_FUNCTION, i);
                 decompiler.Decompile(elf.sections[i].data, elf.sections[i].size, elf.sections[i].offset, i);

--- a/src/binlex.cpp
+++ b/src/binlex.cpp
@@ -24,6 +24,7 @@
 using namespace binlex;
 
 void timeout_handler(int signum) {
+    (void)signum;
     fprintf(stderr, "[x] execution timeout\n");
     exit(0);
 }
@@ -124,7 +125,7 @@ int main(int argc, char **argv){
             }
             si++;
         }
-	cil_decompiler.WriteTraits();
+        cil_decompiler.WriteTraits();
         return EXIT_SUCCESS;
     }
     if (g_args.options.mode == "pe:x86" &&

--- a/src/blelf.cpp
+++ b/src/blelf.cpp
@@ -82,7 +82,7 @@ bool ELF::ParseSections(){
 }
 
 ELF::~ELF(){
-    for (int i = 0; i < total_exec_sections; i++){
+    for (uint32_t i = 0; i < total_exec_sections; i++){
         sections[i].offset = 0;
         sections[i].size = 0;
         free(sections[i].data);

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -82,7 +82,7 @@ string Common::GetFileSHA256(char *file_path){
 string Common::Wildcards(uint count){
     stringstream s;
     s << "";
-    for (int i = 0; i < count; i++){
+    for (uint i = 0; i < count; i++){
         s << "?? ";
     }
     return TrimRight(s.str());
@@ -155,7 +155,7 @@ string Common::WildcardTrait(string trait, string bytes){
         bytes.erase(bytes.length() - 3);
         size_t index = trait.find(bytes, 0);
         if (index != string::npos){
-            for (int j = index; j < trait.length(); j = j + 3){
+            for (size_t j = index; j < trait.length(); j = j + 3){
                 trait.replace(j, 2, "??");
             }
             break;
@@ -168,7 +168,7 @@ string Common::HexdumpBE(const void *data, size_t size){
     stringstream bytes;
     bytes << "";
     const unsigned char *local_pc = (const unsigned char *)data;
-    for (int i = 0; i < size; i++){
+    for (size_t i = 0; i < size; i++){
         bytes << hex << setfill('0') << setw(2) << (uint32_t)local_pc[i] << " ";
     }
     return TrimRight(bytes.str());
@@ -231,4 +231,24 @@ void Common::Hexdump(const char * desc, const void * addr, const int len){
         i++;
     }
     printf ("  %s\n", buff);
+}
+
+TimedCode::TimedCode(const char *tag) {
+    print_tag = tag;
+    start = std::chrono::steady_clock::now();
+}
+
+void TimedCode::Print() {
+    std::chrono::_V2::steady_clock::time_point end = std::chrono::steady_clock::now();
+
+    int64_t start_time = std::chrono::time_point_cast<std::chrono::microseconds>(start).time_since_epoch().count();
+    int64_t end_time = std::chrono::time_point_cast<std::chrono::microseconds>(end).time_since_epoch().count();
+
+    int64_t diff = end_time - start_time;
+    int64_t diff_s = diff / 1000000;
+    int64_t diff_ms = diff / 1000 - diff_s * 1000;
+    int64_t diff_us = diff - diff_s * 1000000 - diff_ms * 1000;
+
+    cerr << "TimedCode: '" << print_tag << "': " << diff_s  << " s "
+         << diff_ms << " ms " << diff_us << " us" << endl;
 }

--- a/src/decompilerbase.cpp
+++ b/src/decompilerbase.cpp
@@ -5,7 +5,7 @@ using namespace binlex;
 DecompilerBase::DecompilerBase(const binlex::File &firef) : file_reference(firef) {
 }
 
-void DecompilerBase::py_SetThreads(uint threads, uint thread_cycles, uint thread_sleep) {
+void DecompilerBase::py_SetThreads(uint threads) {
     g_args.options.threads = threads;
 }
 
@@ -25,8 +25,6 @@ void DecompilerBase::py_SetMode(string mode){
     g_args.options.mode = mode;
 }
 
-// TODO we know how many exec sections we have, we don't need to go through all slots
-// CV to fix by end of GeekWeek 2022
 void DecompilerBase::WriteTraits(){
     std::ofstream output_stream;
     if (g_args.options.output != NULL) {

--- a/src/pe.cpp
+++ b/src/pe.cpp
@@ -127,7 +127,7 @@ bool PE::ParseSections(){
 }
 
 PE::~PE(){
-    for (int i = 0; i < total_exec_sections; i++){
+    for (uint32_t i = 0; i < total_exec_sections; i++){
         sections[i].offset = 0;
         sections[i].size = 0;
         free(sections[i].data);


### PR DESCRIPTION
    - Enable -Wall and -Wextra compilation flag to improve code quality. It is the first step towards enabling -Werror.
    - Fixed couple dozen compilation warnings
    - Fixed a bug in LinearDisassemble found during this exercise.
    - Fix compilation warnings in LinearDisassemble().
    - Add instrumentation for checking the run time of specified code. To check the run time of decompiler.WriteTraits() below the code is wrapped in PERF_START and PERF_END.

Enable compilation flags:
=========================

Before (when building with "make VERBOSE=1"):
/usr/bin/c++  -Dpybinlex_EXPORTS -I/home/cvisinescu/projects/GeekWeek2022/binlex_staging/binlex/include -I/home/cvisinescu/projects/GeekWeek2022/binlex_staging/binlex/build/LIEF/include -I/home/cvisinescu/projects/GeekWeek2022/binlex_staging/binlex/build/capstone/include -I/home/cvisinescu/projects/GeekWeek2022/binlex_staging/binlex/build/tlsh/src/tlsh/include -isystem /home/cvisinescu/projects/GeekWeek2022/binlex_staging/binlex/bindings/python/pybind11/include -isystem /usr/include/python3.8  -fPIC -fvisibility=hidden   -flto -fno-fat-lto-objects -o CMakeFiles/pybinlex.dir/bindings/python/blelf.cpp.o -c /home/cvisinescu/projects/GeekWeek2022/binlex_staging/binlex/bindings/python/blelf.cpp

After (when building with "make VEBOSE=1", notice -Wall, -Wextra):
/usr/bin/c++  -Dbinlex_EXPORTS -I/home/cvisinescu/projects/GeekWeek2022/binlex_staging/binlex/include -I/home/cvisinescu/projects/GeekWeek2022/binlex_staging/binlex/build/LIEF/include -I/home/cvisinescu/projects/GeekWeek2022/binlex_staging/binlex/build/capstone/include -I/home/cvisinescu/projects/GeekWeek2022/binlex_staging/binlex/build/tlsh/src/tlsh/include -I/home/cvisinescu/projects/GeekWeek2022/binlex_staging/binlex/bindings/python/pybind11/include -I/usr/include/python3.8  -Wall -Wextra -fPIC   -DCMAKE_CXX_FLAGS_RELEASE=-O3 -DNDEBUG -o CMakeFiles/binlex.dir/src/blelf.cpp.o -c /home/cvisinescu/projects/GeekWeek2022/binlex_staging/binlex/src/blelf.cpp

Add instrumentation:
====================

            Decompiler decompiler(pe32);
            decompiler.Setup(CS_ARCH_X86, CS_MODE_32);
            for (uint32_t i = 0; i < pe32.total_exec_sections; i++){
                decompiler.AppendQueue(pe32.sections[i].functions, DECOMPILER_OPERAND_TYPE_FUNCTION, i);
                decompiler.Decompile(pe32.sections[i].data, pe32.sections[i].size, pe32.sections[i].offset, i);
            }
            PERF_START("WriteTraits() call");
            decompiler.WriteTraits();
            PERF_END
            return EXIT_SUCCESS;
        }

    The stderr output is:

    cvisinescu@ubuntu ~/p/G/b/binlex (staging)> time build/binlex -m pe:x86 -i tests/pe/pe.delphi.projecthook.x86 > file_delphi.pe
    TimedCode: 'WriteTraits() call': 16 s 320 ms 969 us

    This functionality will be useful when investigating which code gains from multi-threading.

======================

 Changes to be committed:
	modified:   CMakeLists.txt
	modified:   include/common.h
	modified:   include/decompiler.h
	modified:   include/decompilerbase.h
	modified:   src/auto.cpp
	modified:   src/binlex.cpp
	modified:   src/blelf.cpp
	modified:   src/common.cpp
	modified:   src/decompiler.cpp
	modified:   src/decompilerbase.cpp
	modified:   src/pe.cpp