### PR TITLE
Compile on MSVC

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -72,8 +72,11 @@ for:
       # - ps: cd build/
       # - ps: cmake ..
       # - ps: cmake --build . --config Debug
+    build_script:
+      - cmake -B build -DBUILD_PYTHON_BINDINGS=ON "-DPYTHON_EXECUTABLE:FILEPATH=C:\Python310-x64\python.exe"
+      - cmake --build build -j
     artifacts:
-      - path: build/Debug/*.exe
-      - path: build/Debug/*.dll
+      - path: build/Release/*.exe
+      - path: build/Release/*.pyd
 
 build: off

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,21 +1,32 @@
 cmake_minimum_required(VERSION 3.5)
 
-set(VERSION_MAJOR 1)
-set(VERSION_MINOR 1)
-set(VERSION_PATCH 1)
-set(GLOBAL_VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH})
-
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 
 option(BUILD_PYTHON_BINDINGS "Build python bindings (pybinlex)" OFF)
+if(WIN32)
+    # TODO: this can be supported with https://cmake.org/cmake/help/latest/module/GenerateExportHeader.html
+    set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
+else()
+    # NOTE: mutually exclusive with python bindings
+    option(BUILD_SHARED_LIBS "Build binlex as a shared library (linux only)" OFF)
+endif()
+
+# Enable folder support
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 project(binlex
-    VERSION ${GLOBAL_VERSION}
+    VERSION 1.1.1
     DESCRIPTION "A Binary Genetic Traits Lexer and C++ Library"
 )
 
+if(CMAKE_COMPILER_IS_GNUCC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+endif()
+
 if(MSVC)
     add_definitions(-DNOMINMAX)
+    # HACK: be compatible with the ExternalProject's that are built in Release mode
+    string(REPLACE "/RTC1" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
 endif()
 
 include(ExternalProject)
@@ -30,12 +41,13 @@ else()
 endif()
 
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/tests/tests.py
-     DESTINATION ${CMAKE_BINARY_DIR})
+     DESTINATION ${CMAKE_BINARY_DIR}
+)
 
-set(CAPSTONE_ROOT    "${CMAKE_BINARY_DIR}/capstone/")
+set(CAPSTONE_ROOT         "${CMAKE_BINARY_DIR}/capstone/")
 set(CAPSTONE_INCLUDE_DIRS "${CAPSTONE_ROOT}/include/")
-set(CAPSTONE_GIT_URL "https://github.com/capstone-engine/capstone.git")
-set(CAPSTONE_GIT_TAG 4.0.2)
+set(CAPSTONE_GIT_URL      "https://github.com/capstone-engine/capstone.git")
+set(CAPSTONE_GIT_TAG      "4.0.2")
 
 ExternalProject_Add(
     capstone
@@ -76,24 +88,25 @@ ExternalProject_Add(
 )
 
 add_library(capstone_static STATIC IMPORTED)
-set_target_properties(
-    capstone_static PROPERTIES IMPORTED_LOCATION
-    ${CAPSTONE_ROOT}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}capstone${CMAKE_STATIC_LIBRARY_SUFFIX}
+set_target_properties(capstone_static PROPERTIES
+    IMPORTED_LOCATION ${CAPSTONE_ROOT}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}capstone${CMAKE_STATIC_LIBRARY_SUFFIX}
 )
 add_dependencies(capstone_static capstone)
+file(MAKE_DIRECTORY ${CAPSTONE_INCLUDE_DIRS})
+target_include_directories(capstone_static INTERFACE ${CAPSTONE_INCLUDE_DIRS})
 
-set(TLSH_GIT_URL "https://github.com/mrexodia/tlsh.git")
-set(TLSH_ROOT    "${CMAKE_BINARY_DIR}/tlsh/")
+set(TLSH_GIT_URL      "https://github.com/mrexodia/tlsh.git")
+set(TLSH_ROOT         "${CMAKE_BINARY_DIR}/tlsh/")
 set(TLSH_INCLUDE_DIRS "${TLSH_ROOT}/src/tlsh/include/")
 set(TLSH_GIT_TAG      "24d5c0b7fa2ed4d77d9c5dd0c7e1cbf4cd31b42f")
 
 set(TLSH_CMAKE_ARGS
-  -DCMAKE_BUILD_TYPE=Release
-  -DCMAKE_CXX_FLAGS_RELEASE=${CMAKE_CXX_FLAGS_RELEASE}
-  -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-  -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-  -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
-  -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+    -DCMAKE_BUILD_TYPE=Release
+    -DCMAKE_CXX_FLAGS_RELEASE=${CMAKE_CXX_FLAGS_RELEASE}
+    -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+    -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+    -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
+    -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
 )
 
 ExternalProject_Add(
@@ -116,16 +129,14 @@ add_dependencies(tlsh_static tlsh)
 if(WIN32)
     target_compile_definitions(tlsh_static INTERFACE TLSH_WINDOWS)
 endif()
+file(MAKE_DIRECTORY ${TLSH_INCLUDE_DIRS})
+target_include_directories(tlsh_static INTERFACE ${TLSH_INCLUDE_DIRS})
 
 set(LIEF_PREFIX       "${CMAKE_BINARY_DIR}/LIEF/")
 set(LIEF_INSTALL_DIR  "${LIEF_PREFIX}")
 set(LIEF_INCLUDE_DIRS "${LIEF_PREFIX}/include/")
-
-set(LIB_LIEF ${LIEF_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}LIEF${CMAKE_STATIC_LIBRARY_SUFFIX})
-
-set(LIEF_GIT_URL "https://github.com/lief-project/LIEF.git")
-
-set(LIEF_VERSION 0.12.1)
+set(LIEF_GIT_URL      "https://github.com/lief-project/LIEF.git")
+set(LIEF_VERSION      "0.12.1")
 
 set(LIEF_CMAKE_ARGS
   -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
@@ -155,11 +166,12 @@ ExternalProject_Add(LIEF
 )
 
 add_library(lief_static STATIC IMPORTED)
-set_target_properties(
-    lief_static PROPERTIES IMPORTED_LOCATION
-    ${LIEF_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}LIEF${CMAKE_STATIC_LIBRARY_SUFFIX}
+set_target_properties(lief_static PROPERTIES
+    IMPORTED_LOCATION ${LIEF_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}LIEF${CMAKE_STATIC_LIBRARY_SUFFIX}
 )
 add_dependencies(lief_static LIEF)
+file(MAKE_DIRECTORY ${LIEF_INCLUDE_DIRS})
+target_include_directories(lief_static INTERFACE ${LIEF_INCLUDE_DIRS})
 
 add_library(binlex
     src/args.cpp
@@ -176,55 +188,31 @@ add_library(binlex
     src/sha256.c
 )
 
-add_dependencies(binlex LIEF)
-add_dependencies(binlex capstone)
-
-set_target_properties(binlex PROPERTIES SOVERSION ${GLOBAL_VERSION})
+set_target_properties(binlex PROPERTIES SOVERSION ${PROJECT_VERSION})
 
 find_package(Threads REQUIRED)
 
-target_link_libraries(binlex
-    PUBLIC
-        lief_static
-        capstone_static
-        tlsh_static
-        Threads::Threads
-)
-
-set_target_properties(binlex
-	PROPERTIES COMPILE_FLAGS
-	-DCMAKE_CXX_FLAGS_RELEASE=${CMAKE_CXX_FLAGS_RELEASE}
-	-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-	-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+target_link_libraries(binlex PUBLIC
+    lief_static
+    capstone_static
+    tlsh_static
+    Threads::Threads
 )
 
 add_library(binlex::library ALIAS binlex)
 
 if(MSVC)
-  target_compile_options(binlex PUBLIC /FIiso646.h)
+    target_compile_options(binlex PUBLIC /FIiso646.h)
 endif()
 
-target_include_directories(binlex
-    PUBLIC
-        ${PROJECT_SOURCE_DIR}/include
-        ${LIEF_INCLUDE_DIRS}
-        ${CAPSTONE_INCLUDE_DIRS}
-        ${TLSH_INCLUDE_DIRS}
-)
+target_include_directories(binlex PUBLIC include)
 
-if ( CMAKE_COMPILER_IS_GNUCC )
-    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall -Wextra")
-endif()
 add_executable(binlex-bin
     src/binlex.cpp
 )
 
-add_dependencies(binlex-bin LIEF)
-add_dependencies(binlex-bin capstone)
-
-target_link_libraries(binlex-bin
-    PRIVATE
-        binlex::library
+target_link_libraries(binlex-bin PRIVATE
+    binlex::library
 )
 
 set_target_properties(binlex-bin PROPERTIES
@@ -245,25 +233,13 @@ set(SOURCES_BLYARA
 
 add_executable(blyara ${SOURCES_BLYARA})
 
-target_include_directories(blyara
-    PRIVATE
-        ${PROJECT_SOURCE_DIR}/include
-        ${LIEF_INCLUDE_DIRS}
-        ${CAPSTONE_INCLUDE_DIRS}
-        ${TLSH_INCLUDE_DIRS}
-)
+target_include_directories(blyara PRIVATE include)
 
 install(TARGETS blyara DESTINATION bin)
 
 if (BUILD_PYTHON_BINDINGS)
-    include_directories(
-        include/
-        ${pybind11_INCLUDE_DIRS}
-    )
-    link_directories(src/)
-    add_subdirectory(bindings/python/pybind11/)
-    pybind11_add_module(pybinlex
-        SHARED
+    add_subdirectory(bindings/python/pybind11)
+    pybind11_add_module(pybinlex MODULE
         bindings/python/blelf.cpp
         bindings/python/common.cpp
         bindings/python/file.cpp
@@ -272,16 +248,8 @@ if (BUILD_PYTHON_BINDINGS)
         bindings/python/decompiler.cpp
         bindings/python/pybinlex.cpp
     )
-    target_link_libraries(pybinlex
-        PRIVATE
-            pybind11::module
-            binlex::library
-        PUBLIC
-            capstone_static
-            Threads::Threads
-            lief_static
-            tlsh_static
-            ${pybind11_LIBRARIES}
+    target_link_libraries(pybinlex PRIVATE
+        binlex::library
     )
 endif()
 
@@ -290,23 +258,10 @@ add_custom_target(uninstall
 )
 
 set(CPACK_PACKAGE_NAME binlex)
-string(CONCAT PKG_NAME "${CPACK_PACKAGE_NAME}"
-                       "-"
-                       "${VERSION_MAJOR}"
-                       "."
-                       "${VERSION_MINOR}"
-                       "."
-                       "${VERSION_PATCH}"
-)
+set(PKG_NAME "${CPACK_PACKAGE_NAME}-${PROJECT_VERSION}")
 
 SET(CPACK_GENERATOR DEB RPM)
-set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Binary Genetic Traits Lexer Utilities and C++ Library"
-    CACHE STRING "Binary Genetic Traits Lexer Utilities and C++ Library"
-)
 set(CPACK_RESOURCE_FILE_LICENSE "")
-set(CPACK_PACKAGE_VERSION_MAJOR ${VERSION_MAJOR})
-set(CPACK_PACKAGE_VERSION_MINOR ${VERSION_MINOR})
-set(CPACK_PACKAGE_VERSION_PATCH ${VERSION_PATCH})
 set(CPACK_DEBIAN_PACKAGE_MAINTAINER "@c3rb3ru5d3d53c")
 set(CPACK_PACKAGE_CONTACT "c3rb3ru5d3d53c@gmail.com")
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
@@ -334,4 +289,4 @@ set(CPACK_SOURCE_IGNORE_FILES
     "${CPACK_SOURCE_IGNORE_FILES}"
 )
 
-include (CPack)
+include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,20 +7,27 @@ set(GLOBAL_VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH})
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 
+option(BUILD_PYTHON_BINDINGS "Build python bindings (pybinlex)" OFF)
+
 project(binlex
     VERSION ${GLOBAL_VERSION}
     DESCRIPTION "A Binary Genetic Traits Lexer and C++ Library"
 )
 
 if(MSVC)
-    add_definitions(-D_WIN32=1)
-	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
+    add_definitions(-DNOMINMAX)
 endif()
 
 include(ExternalProject)
 include(ProcessorCount)
-
 ProcessorCount(N)
+
+if(CMAKE_GENERATOR MATCHES "Visual Studio")
+    # https://stackoverflow.com/a/70102570/1806760
+    set(EXTERNAL_BUILD_COMMAND cmake --build . --parallel ${N} -- /p:CL_MPcount=${N})
+else()
+    set(EXTERNAL_BUILD_COMMAND cmake --build . --parallel ${N})
+endif()
 
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/tests/tests.py
      DESTINATION ${CMAKE_BINARY_DIR})
@@ -37,7 +44,7 @@ ExternalProject_Add(
     GIT_REPOSITORY      "${CAPSTONE_GIT_URL}"
     GIT_TAG             "${CAPSTONE_GIT_TAG}"
     GIT_SHALLOW         ON
-    BUILD_COMMAND make -j${N}
+    BUILD_COMMAND       ${EXTERNAL_BUILD_COMMAND}
     CMAKE_ARGS          -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
                         -DCAPSTONE_BUILD_SHARED=OFF
                         -DCAPSTONE_BUILD_TESTS=OFF
@@ -75,10 +82,10 @@ set_target_properties(
 )
 add_dependencies(capstone_static capstone)
 
-set(TLSH_GIT_URL "https://github.com/trendmicro/tlsh.git")
+set(TLSH_GIT_URL "https://github.com/mrexodia/tlsh.git")
 set(TLSH_ROOT    "${CMAKE_BINARY_DIR}/tlsh/")
 set(TLSH_INCLUDE_DIRS "${TLSH_ROOT}/src/tlsh/include/")
-set(TLSH_GIT_TAG 4.8.2)
+set(TLSH_GIT_TAG      "24d5c0b7fa2ed4d77d9c5dd0c7e1cbf4cd31b42f")
 
 set(TLSH_CMAKE_ARGS
   -DCMAKE_BUILD_TYPE=Release
@@ -86,6 +93,7 @@ set(TLSH_CMAKE_ARGS
   -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
   -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
   -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
+  -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
 )
 
 ExternalProject_Add(
@@ -95,17 +103,19 @@ ExternalProject_Add(
     GIT_REPOSITORY      "${TLSH_GIT_URL}"
     GIT_TAG             "${TLSH_GIT_TAG}"
     GIT_SHALLOW         ON
-    BUILD_COMMAND make -j${N}
-    INSTALL_COMMAND ""
-    CMAKE_ARGS ${TLSH_CMAKE_ARGS}
+    BUILD_COMMAND       ${EXTERNAL_BUILD_COMMAND}
+    CMAKE_ARGS          ${TLSH_CMAKE_ARGS}
 )
 
 add_library(tlsh_static STATIC IMPORTED)
 set_target_properties(
     tlsh_static PROPERTIES IMPORTED_LOCATION
-    ${TLSH_ROOT}/src/tlsh/lib/${CMAKE_STATIC_LIBRARY_PREFIX}tlsh${CMAKE_STATIC_LIBRARY_SUFFIX}
+    ${TLSH_ROOT}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}tlsh${CMAKE_STATIC_LIBRARY_SUFFIX}
 )
 add_dependencies(tlsh_static tlsh)
+if(WIN32)
+    target_compile_definitions(tlsh_static INTERFACE TLSH_WINDOWS)
+endif()
 
 set(LIEF_PREFIX       "${CMAKE_BINARY_DIR}/LIEF/")
 set(LIEF_INSTALL_DIR  "${LIEF_PREFIX}")
@@ -115,7 +125,7 @@ set(LIB_LIEF ${LIEF_PREFIX}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}LIEF${CMAKE_STATIC
 
 set(LIEF_GIT_URL "https://github.com/lief-project/LIEF.git")
 
-set(LIEF_VERSION 0.11.5)
+set(LIEF_VERSION 0.12.1)
 
 set(LIEF_CMAKE_ARGS
   -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
@@ -135,17 +145,11 @@ set(LIEF_CMAKE_ARGS
   -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
 )
 
-if(MSVC)
-  list(APPEND ${LIEF_CMAKE_ARGS} -DLIEF_USE_CRT_RELEASE=MT)
-endif()
-
-# -DCMAKE_BUILD_TYPE=Release
-
 ExternalProject_Add(LIEF
   PREFIX           ${LIEF_PREFIX}
   GIT_REPOSITORY   ${LIEF_GIT_URL}
   GIT_TAG          ${LIEF_VERSION}
-  BUILD_COMMAND make -j${N}
+  BUILD_COMMAND    ${EXTERNAL_BUILD_COMMAND}
   INSTALL_DIR      ${LIEF_INSTALL_DIR}
   CMAKE_ARGS       ${LIEF_CMAKE_ARGS}
 )
@@ -157,7 +161,7 @@ set_target_properties(
 )
 add_dependencies(lief_static LIEF)
 
-add_library(binlex SHARED
+add_library(binlex
     src/args.cpp
     src/raw.cpp
     src/common.cpp
@@ -177,12 +181,14 @@ add_dependencies(binlex capstone)
 
 set_target_properties(binlex PROPERTIES SOVERSION ${GLOBAL_VERSION})
 
+find_package(Threads REQUIRED)
+
 target_link_libraries(binlex
     PUBLIC
         lief_static
         capstone_static
         tlsh_static
-        -lpthread
+        Threads::Threads
 )
 
 set_target_properties(binlex
@@ -196,7 +202,6 @@ add_library(binlex::library ALIAS binlex)
 
 if(MSVC)
   target_compile_options(binlex PUBLIC /FIiso646.h)
-  set_property(TARGET binlex PROPERTY LINK_FLAGS /NODEFAULTLIB:MSVCRT)
 endif()
 
 target_include_directories(binlex
@@ -222,8 +227,10 @@ target_link_libraries(binlex-bin
         binlex::library
 )
 
-set_target_properties(binlex-bin
-    PROPERTIES OUTPUT_NAME binlex
+set_target_properties(binlex-bin PROPERTIES
+    OUTPUT_NAME binlex
+    ARCHIVE_OUTPUT_NAME binlex-bin # TODO: the executable shouldn't have any exports
+    PDB_NAME binlex-bin
 )
 
 install(TARGETS binlex-bin DESTINATION bin)
@@ -271,7 +278,7 @@ if (BUILD_PYTHON_BINDINGS)
             binlex::library
         PUBLIC
             capstone_static
-            -lpthread
+            Threads::Threads
             lief_static
             tlsh_static
             ${pybind11_LIBRARIES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,12 @@ cmake_minimum_required(VERSION 3.5)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 
 option(BUILD_PYTHON_BINDINGS "Build python bindings (pybinlex)" OFF)
+
+# Linking a pybind11 module with a static library without -fPIC will error
+if(BUILD_PYTHON_BINDINGS)
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+endif()
+
 if(WIN32)
     # TODO: this can be supported with https://cmake.org/cmake/help/latest/module/GenerateExportHeader.html
     set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)

--- a/include/cil.h
+++ b/include/cil.h
@@ -9,7 +9,9 @@
 #include <errno.h>
 #include <inttypes.h>
 #include <assert.h>
+#ifndef _WIN32
 #include <byteswap.h>
+#endif // _WIN32
 #include <ctype.h>
 #include <capstone/capstone.h>
 #include <queue>

--- a/include/file.h
+++ b/include/file.h
@@ -4,7 +4,9 @@
 #include <iostream>
 #include <memory>
 #include <set>
+#ifndef _WIN32
 #include <unistd.h>
+#endif // _WIN32
 #include <string.h>
 #include "common.h"
 

--- a/include/raw.h
+++ b/include/raw.h
@@ -4,7 +4,9 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
+#ifndef _WIN32
 #include <unistd.h>
+#endif // _WIN32
 #include <stdexcept>
 #include "file.h"
 

--- a/include/sha256.h
+++ b/include/sha256.h
@@ -11,24 +11,23 @@
 
 /*************************** HEADER FILES ***************************/
 #include <stddef.h>
+#include <stdint.h>
 
 /****************************** MACROS ******************************/
 #define SHA256_BLOCK_SIZE 32            // SHA256 outputs a 32 byte digest
 
 /**************************** DATA TYPES ****************************/
-typedef unsigned char BYTE;             // 8-bit byte
-typedef unsigned int  WORD;             // 32-bit word, change to "long" for 16-bit machines
 
 typedef struct {
-	BYTE data[64];
-	WORD datalen;
-	unsigned long long bitlen;
-	WORD state[8];
+	uint8_t data[64];
+	uint32_t datalen;
+	uint64_t bitlen;
+	uint32_t state[8];
 } SHA256_CTX;
 
 /*********************** FUNCTION DECLARATIONS **********************/
 void sha256_init(SHA256_CTX *ctx);
-void sha256_update(SHA256_CTX *ctx, const BYTE data[], size_t len);
-void sha256_final(SHA256_CTX *ctx, BYTE hash[]);
+void sha256_update(SHA256_CTX *ctx, const uint8_t data[], size_t len);
+void sha256_final(SHA256_CTX *ctx, uint8_t hash[]);
 
 #endif   // SHA256_H

--- a/src/blelf.cpp
+++ b/src/blelf.cpp
@@ -44,7 +44,7 @@ bool ELF::ReadVector(const std::vector<uint8_t> &data){
 
 bool ELF::ParseSections(){
     uint index = 0;
-    it_sections local_sections = binary->sections();
+    Binary::it_sections local_sections = binary->sections();
     for (auto it = local_sections.begin(); it != local_sections.end(); it++){
         if (it->flags() & (uint64_t)ELF_SECTION_FLAGS::SHF_EXECINSTR){
             sections[index].offset = it->offset();
@@ -53,7 +53,7 @@ bool ELF::ParseSections(){
             memset(sections[index].data, 0, sections[index].size);
             vector<uint8_t> data = binary->get_content_from_virtual_address(it->virtual_address(), it->original_size());
             memcpy(sections[index].data, &data[0], sections[index].size);
-            it_exported_symbols symbols = binary->exported_symbols();
+            Binary::it_exported_symbols symbols = binary->exported_symbols();
             // Add export to function list
             for (auto j = symbols.begin(); j != symbols.end(); j++){
                 uint64_t tmp_offset = binary->virtual_address_to_offset(j->value());

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -62,7 +62,7 @@ string Common::GetFileSHA256(char *file_path){
     SHA256_CTX ctx;
     uint8_t buf[8192];
     size_t bread;
-    BYTE hash[SHA256_BLOCK_SIZE];
+    uint8_t hash[SHA256_BLOCK_SIZE];
     inp = fopen(file_path, "rb");
     if(!inp){
 	    throw std::runtime_error(strerror(errno));
@@ -89,7 +89,7 @@ string Common::Wildcards(uint count){
 }
 
 string Common::GetSHA256(const uint8_t *data, size_t len){
-    BYTE hash[SHA256_BLOCK_SIZE];
+    uint8_t hash[SHA256_BLOCK_SIZE];
     SHA256_CTX ctx;
     sha256_init(&ctx);
     sha256_update(&ctx, data, len);
@@ -98,10 +98,10 @@ string Common::GetSHA256(const uint8_t *data, size_t len){
 }
 
 string Common::SHA256(char *trait){
-    BYTE hash[SHA256_BLOCK_SIZE];
+    uint8_t hash[SHA256_BLOCK_SIZE];
     SHA256_CTX ctx;
     sha256_init(&ctx);
-    sha256_update(&ctx, (BYTE *)trait, strlen(trait));
+    sha256_update(&ctx, (uint8_t *)trait, strlen(trait));
     sha256_final(&ctx, hash);
     return RemoveSpaces(HexdumpBE(&hash, SHA256_BLOCK_SIZE));
 }
@@ -239,7 +239,7 @@ TimedCode::TimedCode(const char *tag) {
 }
 
 void TimedCode::Print() {
-    std::chrono::_V2::steady_clock::time_point end = std::chrono::steady_clock::now();
+    std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
 
     int64_t start_time = std::chrono::time_point_cast<std::chrono::microseconds>(start).time_since_epoch().count();
     int64_t end_time = std::chrono::time_point_cast<std::chrono::microseconds>(end).time_since_epoch().count();

--- a/src/pe.cpp
+++ b/src/pe.cpp
@@ -85,7 +85,7 @@ bool PE::HasLimitations(){
 
 bool PE::ParseSections(){
     uint32_t index = 0;
-    it_sections local_sections = binary->sections();
+    Binary::it_sections local_sections = binary->sections();
     for (auto it = local_sections.begin(); it != local_sections.end(); it++){
         if (it->characteristics() & (uint32_t)SECTION_CHARACTERISTICS::IMAGE_SCN_MEM_EXECUTE){
             sections[index].offset = it->offset();
@@ -97,7 +97,7 @@ bool PE::ParseSections(){
             // Add exports to the function list
             if (binary->has_exports()){
                 Export exports = binary->get_export();
-                it_export_entries export_entries = exports.entries();
+                Export::it_entries export_entries = exports.entries();
                 for (auto j = export_entries.begin(); j != export_entries.end(); j++){
                     PRINT_DEBUG("PE Export offset: 0x%x\n", (int)binary->rva_to_offset(j->address()));
                     uint64_t tmp_offset = binary->rva_to_offset(j->address());

--- a/src/sha256.c
+++ b/src/sha256.c
@@ -17,6 +17,9 @@
 #include <memory.h>
 #include "sha256.h"
 
+typedef uint32_t WORD;
+typedef uint8_t BYTE;
+
 /****************************** MACROS ******************************/
 #define ROTLEFT(a,b) (((a) << (b)) | ((a) >> (32-(b))))
 #define ROTRIGHT(a,b) (((a) >> (b)) | ((a) << (32-(b))))


### PR DESCRIPTION
Unfortunately the CMake is a bit hacky so the fixes are also a bit hacky. In my opinion `ExternalProject_Add` should eventually be replaced with `find_package` (in combination with vcpkg), but LIEF/tlsh (and older versions of capstone) don't have proper packages so this is rather tricky to do for now. Another issue is that there is no support for multi-config generators (like Visual Studio or Ninja) so you might end up with errors trying to build anything but `Release`.

I forked tlsh to https://github.com/mrexodia/tlsh with some changes to the `CMakeLists.txt` to make it work on Windows. The repo seems rather dead so I don't think trying to get this upstream will be successful. Feel free to fork it to your account.

![image](https://user-images.githubusercontent.com/2458265/169715461-59d66843-42fe-4432-a6e9-bc04d28a6a30.png)

Closes #126
Closes #38
Closes #128 