### PR TITLE
Fix for building on macOS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,9 @@ endif()
 if(WIN32)
     # TODO: this can be supported with https://cmake.org/cmake/help/latest/module/GenerateExportHeader.html
     set(BUILD_SHARED_LIBS OFF CACHE BOOL "" FORCE)
+elseif(APPLE)
+    set (CMAKE_C_STANDARD 11)
+    set (CMAKE_CXX_STANDARD 11)
 else()
     # NOTE: mutually exclusive with python bindings
     option(BUILD_SHARED_LIBS "Build binlex as a shared library (linux only)" OFF)

--- a/include/cil.h
+++ b/include/cil.h
@@ -9,7 +9,7 @@
 #include <errno.h>
 #include <inttypes.h>
 #include <assert.h>
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__APPLE__)
 #include <byteswap.h>
 #endif // _WIN32
 #include <ctype.h>


### PR DESCRIPTION
Also to build, flags needed to be set:
```
CFLAGS='-std=c11' CXXFLAGS='-std=c++11' make THREADS=4
```

Built on M1:
```
binlex % file ./build/binlex 
./build/binlex: Mach-O 64-bit executable arm64

binlex % ./build/binlex
binlex v1.1.1 - A Binary Genetic Traits Lexer
  -i  --input		input file		(required)
  -m  --mode		set mode		(optional)
  -lm --list-modes	list modes		(optional)
  -c  --corpus		corpus name		(optional)
  -g  --tag		add a tag		(optional)
           		(can be specified multiple times)
  -t  --threads		number of threads	(optional)
  -to --timeout		execution timeout in s	(optional)
  -h  --help		display help		(optional)
  -o  --output		output file		(optional)
  -p  --pretty		pretty output		(optional)
  -d  --debug		print debug info	(optional)
  -v  --version		display version		(optional)
  ```