### PR TITLE
Segment violations when using the Python binding to the Raw disassembler

### DIFF
--- a/include/raw.h
+++ b/include/raw.h
@@ -36,12 +36,6 @@ namespace binlex{
              * @return int result
              */
             int GetFileSize(FILE *fd);
-            struct Section {
-                void *data;
-                int size;
-                uint offset;
-            };
-            //struct Section sections[BINARY_MAX_SECTIONS];
             BINLEX_EXPORT Raw();
             /**
              * Read data.

--- a/src/raw.cpp
+++ b/src/raw.cpp
@@ -3,6 +3,7 @@
 using namespace binlex;
 
 Raw::Raw(){
+    total_exec_sections = 0;
     for (int i = 0; i < BINARY_MAX_SECTIONS; i++){
         sections[i].offset = 0;
         sections[i].size = 0;
@@ -50,8 +51,9 @@ bool Raw::ReadVector(const std::vector<uint8_t> &data){
 
 Raw::~Raw(){
     for (uint32_t i = 0; i < total_exec_sections; i++){
-        free(sections[i].data);
         sections[i].size = 0;
         sections[i].offset = 0;
+        free(sections[i].data);
+        sections[i].functions.clear();
     }
 }


### PR DESCRIPTION
Believe I have identified the issue total_exec_sections was not being set to 0 in the Raw constructor causing it to be populated with garbage data when overwritten by being created multiple times. I'm creating a branch for this etc so I can resolve it now.