### PR TITLE
Latest Werkzeug is incompatible with blapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Examples of how to use `pybinlex` can be found in `tests/tests.py`.
 ### Install Dependencies
 
 ```bash
-sudo apt install docker.io make
+sudo apt install docker.io docker-compose make
 sudo usermod -a -G docker $USER
 sudo systemctl enable docker
 reboot # ensures your user is added to the docker group
@@ -142,12 +142,12 @@ reboot # ensures your user is added to the docker group
 ### Building Containers
 
 ```bash
-make docker        # generate docker-compose.yml and config files
+make docker             # generate docker-compose.yml and config files
 # Your generated credentials will be printed to the screen and saved in config/credentials.txt
-make docker-build  # build the images (can take a long time, go get a coffee!)
-make docker-start  # start the containers
-make docker-init   # initialize all databases and generated configurations
-make docker-logs   # tail all logs
+sudo make docker-build  # build the images (can take a long time, go get a coffee!)
+make docker-start       # start the containers
+make docker-init        # initialize all databases and generated configurations
+make docker-logs        # tail all logs
 ```
 
 If you wish to change the auto-generated initial username and passwords, you can run `./docker.sh` with additional parameters.

--- a/docker/blapi/Dockerfile
+++ b/docker/blapi/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /opt/binlex/
 RUN apt-get -qq -y update && \
     apt-get install -qq -y build-essential make cmake git wget nano curl nginx net-tools
 
-RUN pip install gunicorn
+RUN pip install Werkzeug==2.1.2 gunicorn
 
 WORKDIR /opt/binlex/lib/python/libblapi/
 


### PR DESCRIPTION
Werkzeug 2.2.0a1 (pre-release) is actually not compatible and prenvents to build Binlex platform.
Full error mesage is available in commit comments