### PR TITLE
fix missing read_vector in python bindings

### DIFF
--- a/bindings/python/raw.cpp
+++ b/bindings/python/raw.cpp
@@ -27,5 +27,6 @@ void init_raw(py::module &handle){
         }
         return result;
     })
+    .def("read_vector", &binlex::Raw::ReadVector)
     .def("read_file", &binlex::Raw::ReadFile);
 }


### PR DESCRIPTION
The read_vector method was missing in the Python binding for the Raw class. It is added in this change.