### PR TITLE
Resolving File Handle Drop for Issue #156

### DIFF
--- a/examples/python/elf.py
+++ b/examples/python/elf.py
@@ -203,7 +203,7 @@ elf = ELF(args.input, config)
 mapped_file = pe.image()
 
 # Get the Memory Map
-image = mapped_file.as_memoryview()
+image = mapped_file.mmap()
 
 # Create Disassembler on Mapped ELF Image and ELF Architecture
 disassembler = Disassembler(elf.architecture(), image, elf.executable_virtual_address_ranges(), config)

--- a/examples/python/macho.py
+++ b/examples/python/macho.py
@@ -205,7 +205,7 @@ for index in macho.number_of_slices():
   mapped_file = macho.image(index)
 
   # Get the Memory Map
-  image = mapped_file.as_memoryview()
+  image = mapped_file.mmap()
 
   # Create Disassembler on Mapped MACHO Image and MACHO Architecture
   disassembler = Disassembler(macho.architecture(index), image, macho.executable_virtual_address_ranges(index), config)

--- a/examples/python/pe_dotnet.py
+++ b/examples/python/pe_dotnet.py
@@ -205,7 +205,7 @@ pe = PE(args.input, config)
 mapped_file = pe.image()
 
 # Get the Memory Map
-image = mapped_file.as_memoryview()
+image = mapped_file.mmap()
 
 # Create Disassembler on Mapped PE Image and PE Architecture
 disassembler = Disassembler(pe.architecture(), image, pe.dotnet_metadata_token_virtual_addresses(), pe.dotnet_executable_virtual_address_ranges(), config)

--- a/examples/python/pe_native.py
+++ b/examples/python/pe_native.py
@@ -205,7 +205,7 @@ pe = PE(args.input, config)
 mapped_file = pe.image()
 
 # Get the Memory Map
-image = mapped_file.as_memoryview()
+image = mapped_file.mmap()
 
 # Create Disassembler on Mapped PE Image and PE Architecture
 disassembler = Disassembler(pe.architecture(), image, pe.executable_virtual_address_ranges(), config)
@@ -216,8 +216,8 @@ cfg = Graph(pe.architecture(), config)
 # Disassemble the PE Image Entrypoints Recursively
 disassembler.disassemble_controlflow(pe.entrypoint_virtual_addresses(), cfg)
 
-# for address in cfg.queue_functions.valid_addresses():
-#     function = Function(address, cfg)
-#     function.print()
+for address in cfg.queue_functions.valid_addresses():
+    function = Function(address, cfg)
+    function.print()
 # for function in cfg.functions():
 #     function.print()

--- a/examples/python/pe_native_compare.py
+++ b/examples/python/pe_native_compare.py
@@ -232,7 +232,7 @@ rhs_pe = PE(args.rhs, config)
 rhs_mapped_file = rhs_pe.image()
 
 # Get the Memory Map
-rhs_image = rhs_mapped_file.as_memoryview()
+rhs_image = rhs_mapped_file.mmap()
 
 # Create Disassembler on Mapped PE Image and PE Architecture
 rhs_disassembler = Disassembler(rhs_pe.architecture(), rhs_image, rhs_pe.executable_virtual_address_ranges(), config)

--- a/scripts/plugins/ida/binlex/main.py
+++ b/scripts/plugins/ida/binlex/main.py
@@ -367,7 +367,7 @@ class BinlexPlugin(idaapi.plugin_t):
             self.mapped_file.seek_to_end()
             self.mapped_file.write(data)
         self.executable_address_ranges = {0: self.mapped_file.size()}
-        self.image = self.mapped_file.as_memoryview()
+        self.image = self.mapped_file.mmap()
 
     def load_binary(self) -> bool:
         if ida_ida.inf_get_procname() == 'metapc':

--- a/src/bin/binlex.rs
+++ b/src/bin/binlex.rs
@@ -638,7 +638,7 @@ fn process_pe(input: String, config: Config, tags: Option<Vec<String>>, output: 
     //     attributes.push(Attribute::Symbol(symbol.process().clone()));
     // }
 
-    let mapped_file = pe.image()
+    let mut mapped_file = pe.image()
         .unwrap_or_else(|error| { eprintln!("failed to map pe image: {}", error); process::exit(1)});
 
     Stderr::print_debug(config.clone(), "mapped pe image");
@@ -737,7 +737,7 @@ fn process_elf(input: String, config: Config, tags: Option<Vec<String>>, output:
     //     attributes.push(Attribute::Symbol(symbol.process().clone()));
     // }
 
-    let mapped_file = elf.image()
+    let mut mapped_file = elf.image()
         .unwrap_or_else(|error| { eprintln!("{}", error); process::exit(1)});
 
     let image = mapped_file
@@ -864,7 +864,7 @@ fn process_macho(input: String, config: Config, tags: Option<Vec<String>>, outpu
         //     attributes.push(Attribute::Symbol(symbol.process().clone()));
         // }
 
-        let mapped_file = macho.image(slice)
+        let mut mapped_file = macho.image(slice)
         .unwrap_or_else(|error| { eprintln!("{}", error); process::exit(1)});
 
         let image = mapped_file

--- a/src/bindings/python/src/formats/elf.rs
+++ b/src/bindings/python/src/formats/elf.rs
@@ -236,7 +236,7 @@ impl ELF {
         let result = self.inner.lock().unwrap().image().map_err(|e| {
             pyo3::exceptions::PyIOError::new_err(e.to_string())
         })?;
-        let py_memory_mapped_file = Py::new(py, MemoryMappedFile { inner: result, mmap: None})?;
+        let py_memory_mapped_file = Py::new(py, MemoryMappedFile { inner: result})?;
         Ok(py_memory_mapped_file)
     }
 

--- a/src/bindings/python/src/formats/macho.rs
+++ b/src/bindings/python/src/formats/macho.rs
@@ -258,7 +258,7 @@ impl MACHO {
         let result = self.inner.lock().unwrap().image(slice).map_err(|e| {
             pyo3::exceptions::PyIOError::new_err(e.to_string())
         })?;
-        let py_memory_mapped_file = Py::new(py, MemoryMappedFile { inner: result, mmap: None})?;
+        let py_memory_mapped_file = Py::new(py, MemoryMappedFile { inner: result})?;
         Ok(py_memory_mapped_file)
     }
 

--- a/src/bindings/python/src/formats/pe.rs
+++ b/src/bindings/python/src/formats/pe.rs
@@ -282,7 +282,7 @@ impl PE {
         let result = self.inner.lock().unwrap().image().map_err(|e| {
             pyo3::exceptions::PyIOError::new_err(e.to_string())
         })?;
-        let py_memory_mapped_file = Py::new(py, MemoryMappedFile { inner: result, mmap: None})?;
+        let py_memory_mapped_file = Py::new(py, MemoryMappedFile { inner: result})?;
         Ok(py_memory_mapped_file)
     }
 

--- a/src/bindings/python/src/types/memorymappedfile.rs
+++ b/src/bindings/python/src/types/memorymappedfile.rs
@@ -167,7 +167,6 @@
 use pyo3::prelude::*;
 use pyo3::exceptions;
 use pyo3::types::PyMemoryView;
-use memmap2::Mmap;
 use binlex::types::MemoryMappedFile as InnerMemoryMappedFile;
 use pyo3::ffi;
 use std::os::raw::c_char;
@@ -175,7 +174,6 @@ use std::os::raw::c_char;
 #[pyclass]
 pub struct MemoryMappedFile {
     pub inner: InnerMemoryMappedFile,
-    pub mmap: Option<Mmap>,
 }
 
 #[pymethods]
@@ -186,7 +184,7 @@ impl MemoryMappedFile {
         let path = std::path::PathBuf::from(path);
         let inner = InnerMemoryMappedFile::new(path, cache)
             .map_err(|e| exceptions::PyIOError::new_err(e.to_string()))?;
-        Ok(MemoryMappedFile { inner: inner, mmap: None })
+        Ok(MemoryMappedFile { inner })
     }
 
     #[pyo3(text_signature = "($self)")]
@@ -222,7 +220,7 @@ impl MemoryMappedFile {
     }
 
     #[pyo3(text_signature = "($self, offset)")]
-    pub fn seek(&mut self, offset: u64) -> PyResult<u64>{
+    pub fn seek(&mut self, offset: u64) -> PyResult<u64> {
         self.inner
             .seek(offset)
             .map_err(|e| exceptions::PyIOError::new_err(e.to_string()))
@@ -235,73 +233,40 @@ impl MemoryMappedFile {
             .map_err(|e| exceptions::PyIOError::new_err(e.to_string()))
     }
 
-    /// Maps the file into memory and returns a MappedFile object.
     #[pyo3(text_signature = "($self)")]
-    pub fn mmap(&self) -> PyResult<MappedFile> {
+    pub fn mmap<'py>(&'py mut self, py: Python<'py>) -> PyResult<Py<PyMemoryView>> {
         let mmap = self
             .inner
             .mmap()
             .map_err(|e| exceptions::PyIOError::new_err(e.to_string()))?;
-        Ok(MappedFile { mmap })
-    }
-
-    /// Maps the file into memory and returns a memoryview without copying data.
-    #[pyo3(text_signature = "($self)")]
-    pub fn as_memoryview<'py>(&mut self, py: Python<'py>) -> PyResult<Bound<'py, PyMemoryView>> {
-        if self.mmap.is_none() {
-            let mmap = self
-                .inner
-                .mmap()
-                .map_err(|e| exceptions::PyIOError::new_err(e.to_string()))?;
-            self.mmap = Some(mmap);
-        }
-        if let Some(mmap) = &self.mmap {
-            let data = &mmap[..];
-            let ptr = data.as_ptr() as *mut c_char;
-            let len = data.len() as ffi::Py_ssize_t;
-            unsafe {
-                // Create a raw memoryview pointer without copying data
-                let memview_ptr = ffi::PyMemoryView_FromMemory(ptr, len, ffi::PyBUF_READ);
-                if memview_ptr.is_null() {
-                    Err(PyErr::fetch(py))
-                } else {
-                    // Convert the raw pointer into a PyObject
-                    let obj = PyObject::from_owned_ptr(py, memview_ptr);
-                    // Use downcast_bound to convert PyObject to Bound<'py, PyMemoryView>
-                    let memview = obj.downcast_bound::<PyMemoryView>(py)?;
-                    Ok(memview.clone())
-                }
-            }
-        } else {
-            Err(exceptions::PyRuntimeError::new_err("Failed to map file"))
-        }
-    }
-
-}
-
-#[pyclass]
-pub struct MappedFile {
-    mmap: Mmap,
-}
-
-#[pymethods]
-impl MappedFile {
-    /// Returns a memoryview of the mapped file without copying data into RAM.
-    pub fn as_memoryview<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyMemoryView>> {
-        let data = &self.mmap[..];
+        let data = &mmap[..];
         let ptr = data.as_ptr() as *mut c_char;
         let len = data.len() as ffi::Py_ssize_t;
         unsafe {
-            // Create a raw memoryview pointer without copying data
             let memview_ptr = ffi::PyMemoryView_FromMemory(ptr, len, ffi::PyBUF_READ);
             if memview_ptr.is_null() {
                 Err(PyErr::fetch(py))
             } else {
-                // Convert the raw pointer into a PyObject
-                let obj = PyObject::from_owned_ptr(py, memview_ptr);
-                // Use downcast_bound to convert PyObject to Bound<'py, PyMemoryView>
-                let memview = obj.downcast_bound::<PyMemoryView>(py)?;
-                Ok(memview.clone())
+                Ok(Py::from_owned_ptr(py, memview_ptr))
+            }
+        }
+    }
+
+    #[pyo3(text_signature = "($self)")]
+    pub fn mmap_mut<'py>(&'py mut self, py: Python<'py>) -> PyResult<Py<PyMemoryView>> {
+        let mmap = self
+            .inner
+            .mmap_mut()
+            .map_err(|e| exceptions::PyIOError::new_err(e.to_string()))?;
+        let data = &mmap[..];
+        let ptr = data.as_ptr() as *mut c_char;
+        let len = data.len() as ffi::Py_ssize_t;
+        unsafe {
+            let memview_ptr = ffi::PyMemoryView_FromMemory(ptr, len, ffi::PyBUF_WRITE);
+            if memview_ptr.is_null() {
+                Err(PyErr::fetch(py))
+            } else {
+                Ok(Py::from_owned_ptr(py, memview_ptr))
             }
         }
     }
@@ -311,10 +276,10 @@ impl MappedFile {
 #[pyo3(name = "memorymappedfile")]
 pub fn memorymappedfile_init(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<MemoryMappedFile>()?;
-    m.add_class::<MappedFile>()?;
     py.import_bound("sys")?
         .getattr("modules")?
         .set_item("binlex.types.memorymappedfile", m)?;
     m.setattr("__name__", "binlex.types.memorymappedfile")?;
     Ok(())
 }
+


### PR DESCRIPTION
There were two main issues here causing this to not working on Windows.

1. We did not have the permissions for `FILE_SHARE_DELETE`
2. We cannot own the `mmap`, it must be owned and explicitly dropped by the `MemoryMappedFile` implementation when it goes out of scope using `Drop`.

This does change the API now a bit but is it is more consistent with the Rust API.

Instead of doing `.as_memoryview()` you can now use `.mmap()`, which is more consistent with the Rust API, but in Python where you get a `memoryview` instead of a `Mmap`.