### PR TITLE
Fix CFG block parsing bug

### DIFF
--- a/src/controlflow/function.rs
+++ b/src/controlflow/function.rs
@@ -971,7 +971,16 @@ impl<'function> Function<'function> {
     ///
     /// Returns `Some(usize)` if the function is contiguous; otherwise, `None`.
     pub fn size(&self) -> usize {
-        self.blocks.values().map(|block| block.size()).sum()
+        if self.blocks.is_empty() {
+            return 0;
+        }
+        let end = self
+            .blocks
+            .values()
+            .map(|b| b.address + b.size() as u64)
+            .max()
+            .unwrap_or(self.address);
+        (end - self.address) as usize
     }
 
     /// Retrieves the address of the function's last instruction, if contiguous.

--- a/src/controlflow/function.rs
+++ b/src/controlflow/function.rs
@@ -995,22 +995,24 @@ impl<'function> Function<'function> {
     ///
     /// Returns `Some(Vec<u8>)` containing the bytes, or `None` if the function is not contiguous.
     pub fn bytes(&self) -> Option<Vec<u8>> {
-        if !self.contiguous() {
+        if self.blocks.is_empty() {
             return None;
         }
+        let end = self
+            .blocks
+            .values()
+            .map(|b| b.address + b.size() as u64)
+            .max()
+            .unwrap_or(self.address);
         let mut bytes = Vec::<u8>::new();
-        let mut block_previous_end: Option<u64> = None;
-        for (block_start_address, block) in &self.blocks {
-            bytes.extend(block.bytes());
-            if block.terminator.is_return {
-                break;
-            }
-            if let Some(previous_end) = block_previous_end {
-                if previous_end != *block_start_address {
-                    return None;
-                }
-            }
-            block_previous_end = Some(block.address + block.size() as u64);
+        let mut pc = self.address;
+        while pc < end {
+            let instruction = match self.cfg.get_instruction(pc) {
+                Some(i) => i,
+                None => return None,
+            };
+            bytes.extend(&instruction.bytes);
+            pc += instruction.size() as u64;
         }
         Some(bytes)
     }
@@ -1135,14 +1137,21 @@ impl<'function> Function<'function> {
     ///
     /// Returns `true` if the function is contiguous; otherwise, `false`.
     pub fn contiguous(&self) -> bool {
-        let mut block_previous_end: Option<u64> = None;
-        for (block_start_address, block) in &self.blocks {
-            if let Some(previous_end) = block_previous_end {
-                if previous_end != *block_start_address {
-                    return false;
-                }
+        if self.blocks.is_empty() {
+            return false;
+        }
+        let end = self
+            .blocks
+            .values()
+            .map(|b| b.address + b.size() as u64)
+            .max()
+            .unwrap_or(self.address);
+        let mut pc = self.address;
+        while pc < end {
+            match self.cfg.get_instruction(pc) {
+                Some(instr) => pc += instr.size() as u64,
+                None => return false,
             }
-            block_previous_end = Some(block.address + block.size() as u64);
         }
         true
     }

--- a/src/controlflow/graph.rs
+++ b/src/controlflow/graph.rs
@@ -406,6 +406,15 @@ impl GraphQueue {
         true
     }
 
+    /// Checks if an address is currently pending in the queue.
+    ///
+    /// # Returns
+    ///
+    /// Returns `true` if the address is pending processing, otherwise `false`.
+    pub fn is_pending(&self, address: u64) -> bool {
+        self.pending.contains(&address)
+    }
+
     /// Removes an address from the processing queue.
     ///
     /// # Returns

--- a/tests/test_block_split.rs
+++ b/tests/test_block_split.rs
@@ -43,5 +43,9 @@ fn test_full_function_disassembly() {
         let instr = graph.get_instruction(addr).unwrap();
         collected.extend(instr.bytes);
     }
-    assert_eq!(Binary::to_hex(&collected), hex, "function bytes mismatch");
+    assert_eq!(Binary::to_hex(&collected), hex, "listing bytes mismatch");
+
+    // ensure that the bytes returned by Function::bytes() match the input
+    let func_bytes = func.bytes().expect("function bytes");
+    assert_eq!(Binary::to_hex(&func_bytes), hex, "function bytes mismatch");
 }

--- a/tests/test_block_split.rs
+++ b/tests/test_block_split.rs
@@ -48,4 +48,7 @@ fn test_full_function_disassembly() {
     // ensure that the bytes returned by Function::bytes() match the input
     let func_bytes = func.bytes().expect("function bytes");
     assert_eq!(Binary::to_hex(&func_bytes), hex, "function bytes mismatch");
+
+    // verify the function is contiguous
+    assert!(func.contiguous(), "function should be contiguous");
 }

--- a/tests/test_block_split.rs
+++ b/tests/test_block_split.rs
@@ -38,4 +38,10 @@ fn test_full_function_disassembly() {
     let func = Function::new(0, &graph).expect("function");
     assert_eq!(graph.listing.len(), 62, "incorrect instruction count");
     assert_eq!(func.blocks.len(), 14, "incorrect block count");
+    let mut collected = Vec::<u8>::new();
+    for addr in graph.instruction_addresses().iter().copied() {
+        let instr = graph.get_instruction(addr).unwrap();
+        collected.extend(instr.bytes);
+    }
+    assert_eq!(Binary::to_hex(&collected), hex, "function bytes mismatch");
 }

--- a/tests/test_block_split.rs
+++ b/tests/test_block_split.rs
@@ -1,0 +1,41 @@
+use binlex::binary::Binary;
+use binlex::controlflow::{Graph, Function};
+use binlex::disassemblers::capstone::Disassembler;
+use binlex::{Architecture, Config};
+use std::collections::BTreeMap;
+
+#[test]
+fn test_block_split_pending() {
+    // assembly: jz 0x4; nop; nop; ret
+    let bytes = vec![0x74, 0x02, 0x90, 0x90, 0xc3];
+    let mut ranges = BTreeMap::new();
+    ranges.insert(0u64, bytes.len() as u64);
+    let config = Config::new();
+    let disasm = Disassembler::new(Architecture::I386, &bytes, ranges.clone(), config.clone()).expect("disasm");
+    let mut graph = Graph::new(Architecture::I386, config.clone());
+    // pre-mark address 2 as a block start
+    graph.blocks.enqueue(2);
+    disasm.disassemble_function(0, &mut graph).expect("disassemble");
+    let func = Function::new(0, &graph).expect("function");
+    let mut blocks = func.blocks.iter();
+    let first = blocks.next().unwrap().1;
+    assert_eq!(Binary::to_hex(&first.bytes()), "7402", "first block incorrect");
+}
+
+#[test]
+fn test_full_function_disassembly() {
+    let hex = "558bec5657668b7d0c33f6833d88cc4300020fb7d77d2a8b4d088bf1668b0183c1026685c075f583e9023bce740966393975f48bc1eb6733c06639110f44c1eb5d8b5508eb110fb702663bc70f44f26685c0744883c2028d4201a80e75e833c0663bc7751eb80100ffff660f6ec8eb0383c2100f1002660f3a63c81575f28d044aeb1b0fb7c7660f6ec0660f3a63024173038d344a740583c210ebee8bc65f5e5dc3";
+    let bytes: Vec<u8> = (0..hex.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).unwrap())
+        .collect();
+    let mut ranges = BTreeMap::new();
+    ranges.insert(0u64, bytes.len() as u64);
+    let config = Config::new();
+    let disasm = Disassembler::new(Architecture::I386, &bytes, ranges.clone(), config.clone()).expect("disasm");
+    let mut graph = Graph::new(Architecture::I386, config.clone());
+    disasm.disassemble_function(0, &mut graph).expect("disassemble");
+    let func = Function::new(0, &graph).expect("function");
+    assert_eq!(graph.listing.len(), 62, "incorrect instruction count");
+    assert_eq!(func.blocks.len(), 14, "incorrect block count");
+}


### PR DESCRIPTION
## Summary
- fix block boundary detection when pending addresses exist
- expose `is_pending` in `GraphQueue`
- add unit test for disassembler block splitting
- add test covering entire problematic function bytes

## Testing
- `cargo test --quiet`
- `cargo build --release --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687a2f2f7a7483329c31f206d9f83912